### PR TITLE
Prevent a file to open in the window on drop

### DIFF
--- a/main/main.js
+++ b/main/main.js
@@ -5,6 +5,7 @@ const path = require('path');
 const template = require('./menus/file');
 const registerShortcuts = require('./localShortcuts');
 const registerIpcListeners = require('./ipcMainListeners');
+const registerWebContentsListeners = require('./webContentsListeners');
 const fs = require('fs');
 require('electron-debug')();
 
@@ -45,4 +46,5 @@ app.on('ready', async () => {
 
   global.mainWindow = win;
   registerShortcuts(win);
+  registerWebContentsListeners(win);
 });

--- a/main/webContentsListeners.js
+++ b/main/webContentsListeners.js
@@ -1,0 +1,7 @@
+
+module.exports = (win) => {
+  // Prevent window to open the file on drop
+  win.webContents.on('will-navigate', (event) => {
+    event.preventDefault();
+  });
+}


### PR DESCRIPTION
This change prevents a file which browser recognises to open in the BrowserWindow on drag and drop.