### PR TITLE
Removed fs module from dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,5 @@ Managing state across a complex web of React components is the biggest pain poin
 ## Synchronized property and style controls
 Code is the representation of user interfaces, but writing code rarely ever resembles it. By cross-utilizing Reactide’s tools, properties and styles can be edited through straightforward GUI controls that provide immediate feedback in the browser simulator. The cumbersome process of having to wait and transpile every minor edit to a project is now instant.
 
-## How to install
-
-Run `npm run dev` in one terminal.
-
-Once the webpack server has started open another terminal and run `npm run dev-start`.
-
-You can also run `npm start`, however please note that live reloading will then not be available.
-
 ## Contributors
 [Jin Choi](https://github.com/jinihendrix) | [Mark Marcelo](https://github.com/markmarcelo) | [Bita Djaghouri](https://github.com/bitadj)

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "electron": "^1.6.1",
     "electron-debug": "^1.1.0",
     "electron-localshortcut": "^1.1.0",
-    "fs": "0.0.1-security",
     "monaco-editor": "^0.8.3",
     "path": "^0.12.7",
     "react": "^15.4.2",


### PR DESCRIPTION
`fs` is a core node module and should not be installed via `npm`.